### PR TITLE
[#7] As a guest, I can see the sign-in page

### DIFF
--- a/cypress/integration/User/login.spec.ts
+++ b/cypress/integration/User/login.spec.ts
@@ -1,0 +1,9 @@
+/// <reference types="cypress" />
+
+describe('Login page', () => {
+  it('displays welcome message', () => {
+    cy.visit('/user/login');
+
+    cy.get('h1').contains('Welcome to login page!!');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ const customJestConfig = {
   moduleDirectories: ['node_modules', '<rootDir>/'],
   moduleNameMapper: {
     '^@/components/(.*)$': '<rootDir>/src/components/$1',
+    '^@/layouts/(.*)$': '<rootDir>/src/layouts/$1',
   },
   modulePathIgnorePatterns: ['cypress'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],

--- a/src/components/AvatarBot/index.test.tsx
+++ b/src/components/AvatarBot/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 
-import AvatarBot, { avatarBotTestIds } from '@/components/AvatarBot';
+import AvatarBot, { avatarBotTestIds } from './index';
 
 describe('AvatarBot', () => {
   it('renders avatar with the given email', () => {

--- a/src/constants/seo.ts
+++ b/src/constants/seo.ts
@@ -1,0 +1,5 @@
+const SEO_TITLE = 'Internal Certification : React + Next.js';
+const SEO_DESCRIPTION =
+  'A project to challenge ourselves with specific web stacks to achieve the Internal Certification. 🚀';
+
+export { SEO_TITLE, SEO_DESCRIPTION };

--- a/src/layouts/Authentication/index.test.tsx
+++ b/src/layouts/Authentication/index.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+
+import LayoutAuthentication, {
+  layoutAuthenticationTestIds,
+} from '@/layouts/Authentication';
+
+describe('Authentication Layout', () => {
+  it('renders authentication layout', () => {
+    render(<LayoutAuthentication>&nbsp;</LayoutAuthentication>);
+
+    const layout = screen.getByTestId(layoutAuthenticationTestIds.base);
+
+    expect(layout).toBeVisible();
+  });
+});

--- a/src/layouts/Authentication/index.test.tsx
+++ b/src/layouts/Authentication/index.test.tsx
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import LayoutAuthentication, {
-  layoutAuthenticationTestIds,
-} from '@/layouts/Authentication';
+import LayoutAuthentication, { layoutAuthenticationTestIds } from './index';
 
 describe('Authentication Layout', () => {
   it('renders authentication layout', () => {

--- a/src/layouts/Authentication/index.tsx
+++ b/src/layouts/Authentication/index.tsx
@@ -1,9 +1,5 @@
-import { useEffect } from 'react';
-
-const layoutClassName = 'layout-authentication';
-
 export const layoutAuthenticationTestIds = {
-  base: layoutClassName,
+  base: 'layout-authentication',
 };
 
 interface LayoutProps {
@@ -11,10 +7,6 @@ interface LayoutProps {
 }
 
 const LayoutAuthentication = ({ children }: LayoutProps) => {
-  useEffect(() => {
-    document.body.classList.add(layoutClassName);
-  }, []);
-
   return (
     <>
       <main

--- a/src/layouts/Authentication/index.tsx
+++ b/src/layouts/Authentication/index.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
 const LayoutAuthentication = ({ children }: LayoutProps) => {
   useEffect(() => {
     document.body.classList.add(layoutClassName);
-  });
+  }, []);
 
   return (
     <>

--- a/src/layouts/Authentication/index.tsx
+++ b/src/layouts/Authentication/index.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+const layoutClassName = 'layout-authentication';
+
+export const layoutAuthenticationTestIds = {
+  base: layoutClassName,
+};
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const LayoutAuthentication = ({ children }: LayoutProps) => {
+  useEffect(() => {
+    document.body.classList.add(layoutClassName);
+  });
+
+  return (
+    <>
+      <main
+        className="app-content"
+        data-test-id={layoutAuthenticationTestIds.base}
+      >
+        {children}
+      </main>
+    </>
+  );
+};
+
+export default LayoutAuthentication;

--- a/src/layouts/Default/index.test.tsx
+++ b/src/layouts/Default/index.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+
+import LayoutDefault, { layoutDefaultTestIds } from '@/layouts/Default';
+
+describe('Authentication Layout', () => {
+  it('renders authentication layout', () => {
+    render(<LayoutDefault>&nbsp;</LayoutDefault>);
+
+    const layout = screen.getByTestId(layoutDefaultTestIds.base);
+
+    expect(layout).toBeVisible();
+  });
+});

--- a/src/layouts/Default/index.test.tsx
+++ b/src/layouts/Default/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import LayoutDefault, { layoutDefaultTestIds } from '@/layouts/Default';
+import LayoutDefault, { layoutDefaultTestIds } from './index';
 
 describe('Authentication Layout', () => {
   it('renders authentication layout', () => {

--- a/src/layouts/Default/index.tsx
+++ b/src/layouts/Default/index.tsx
@@ -1,9 +1,5 @@
-import { useEffect } from 'react';
-
-const layoutClassName = 'layout-default';
-
 export const layoutDefaultTestIds = {
-  base: layoutClassName,
+  base: 'layout-default',
 };
 
 interface LayoutProps {
@@ -11,10 +7,6 @@ interface LayoutProps {
 }
 
 const LayoutDefault = ({ children }: LayoutProps) => {
-  useEffect(() => {
-    document.body.classList.add(layoutClassName);
-  }, []);
-
   return (
     <>
       <main className="app-content" data-test-id={layoutDefaultTestIds.base}>

--- a/src/layouts/Default/index.tsx
+++ b/src/layouts/Default/index.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+const layoutClassName = 'layout-default';
+
+export const layoutDefaultTestIds = {
+  base: layoutClassName,
+};
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const LayoutDefault = ({ children }: LayoutProps) => {
+  useEffect(() => {
+    document.body.classList.add(layoutClassName);
+  });
+
+  return (
+    <>
+      <main className="app-content" data-test-id={layoutDefaultTestIds.base}>
+        {children}
+      </main>
+    </>
+  );
+};
+
+export default LayoutDefault;

--- a/src/layouts/Default/index.tsx
+++ b/src/layouts/Default/index.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
 const LayoutDefault = ({ children }: LayoutProps) => {
   useEffect(() => {
     document.body.classList.add(layoutClassName);
-  });
+  }, []);
 
   return (
     <>

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,0 +1,4 @@
+import LayoutAuthentication from './Authentication';
+import LayoutDefault from './Default';
+
+export { LayoutAuthentication, LayoutDefault };

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,13 +1,34 @@
-import { ChakraProvider } from '@chakra-ui/react';
-import type { AppProps } from 'next/app';
+import type { ReactElement, ReactNode } from 'react';
 
+import { ChakraProvider } from '@chakra-ui/react';
+import type { NextPage } from 'next';
+import type { AppProps } from 'next/app';
+import Head from 'next/head';
+
+import { SEO_TITLE, SEO_DESCRIPTION } from '@/constants/seo';
 import { theme } from '@/theme/index';
 
-import '@/styles/globals.scss';
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
 
-function App({ Component, pageProps }: AppProps) {
-  return (
-    <ChakraProvider theme={theme}>
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+function App({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => page);
+
+  return getLayout(
+    <ChakraProvider resetCSS theme={theme}>
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        <title>{SEO_TITLE}</title>
+        <meta name="description" content={SEO_DESCRIPTION} />
+      </Head>
       <Component {...pageProps} />
     </ChakraProvider>
   );

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,3 +1,4 @@
+import '@/styles/globals.scss';
 import type { ReactElement, ReactNode } from 'react';
 
 import { ChakraProvider } from '@chakra-ui/react';

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -13,17 +13,17 @@ import {
   Input,
   useDisclosure,
 } from '@chakra-ui/react';
-import type { NextPage } from 'next';
 import Image from 'next/image';
 
 import AvatarBot from '@/components/AvatarBot';
+import LayoutDefault from '@/layouts/Default';
 import styles from '@/styles/Home.module.scss';
 
 export const homeDataTestIds = {
   heading: 'home-heading',
 };
 
-const Home: NextPage = () => {
+const Home = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const cancelRef = useRef<HTMLButtonElement>(null);
 
@@ -163,6 +163,10 @@ const Home: NextPage = () => {
       </footer>
     </div>
   );
+};
+
+Home.getLayout = (page: React.ReactNode) => {
+  return <LayoutDefault>{page}</LayoutDefault>;
 };
 
 export default Home;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -16,7 +16,7 @@ import {
 import Image from 'next/image';
 
 import AvatarBot from '@/components/AvatarBot';
-import LayoutDefault from '@/layouts/Default';
+import { LayoutDefault } from '@/layouts/index';
 import styles from '@/styles/Home.module.scss';
 
 export const homeDataTestIds = {

--- a/src/pages/user/login.page.tsx
+++ b/src/pages/user/login.page.tsx
@@ -1,4 +1,4 @@
-import LayoutAuthentication from '@/layouts/Authentication';
+import { LayoutAuthentication } from '@/layouts/index';
 
 export const loginDataTestIds = {
   heading: 'login-heading',

--- a/src/pages/user/login.page.tsx
+++ b/src/pages/user/login.page.tsx
@@ -1,0 +1,7 @@
+import type { NextPage } from 'next';
+
+const Login: NextPage = () => {
+  return <h1>Welcome to login page!!</h1>;
+};
+
+export default Login;

--- a/src/pages/user/login.page.tsx
+++ b/src/pages/user/login.page.tsx
@@ -1,7 +1,17 @@
-import type { NextPage } from 'next';
+import LayoutAuthentication from '@/layouts/Authentication';
 
-const Login: NextPage = () => {
-  return <h1>Welcome to login page!!</h1>;
+export const loginDataTestIds = {
+  heading: 'login-heading',
+};
+
+const Login = () => {
+  return (
+    <h1 data-test-id={loginDataTestIds.heading}>Welcome to login page!!</h1>
+  );
+};
+
+Login.getLayout = (page: React.ReactNode) => {
+  return <LayoutAuthentication>{page}</LayoutAuthentication>;
 };
 
 export default Login;

--- a/src/pages/user/login.test.tsx
+++ b/src/pages/user/login.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+
+import Login from './login.page';
+
+describe('Login', () => {
+  it('renders a heading', () => {
+    render(<Login />);
+
+    const heading = screen.getByRole('heading', {
+      name: /welcome to login page!!/i,
+    });
+
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/src/pages/user/login.test.tsx
+++ b/src/pages/user/login.test.tsx
@@ -1,14 +1,12 @@
 import { render, screen } from '@testing-library/react';
 
-import Login from './login.page';
+import Login, { loginDataTestIds } from './login.page';
 
 describe('Login', () => {
   it('renders a heading', () => {
     render(<Login />);
 
-    const heading = screen.getByRole('heading', {
-      name: /welcome to login page!!/i,
-    });
+    const heading = screen.getByTestId(loginDataTestIds.heading);
 
     expect(heading).toBeInTheDocument();
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,8 @@
     "baseUrl": "./src",
     "paths": {
       "@/components/*": ["components/*"],
+      "@/constants/*": ["constants/*"],
+      "@/layouts/*": ["layouts/*"],
       "@/styles/*": ["styles/*"],
       "@/theme/*": ["theme/*"],
     }


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1s1L2a3S4hHzhpWuT2a7ACGOtAPfCeM0JNZp1L2u3SpcaVaAe1Q2u3A4l%2Fcollaboration.svg)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=z5ollcC)

* Resolve [As a guest, I can see the sign-in page #7 ](https://github.com/Lahphim/react-surveyor-challenge/issues/7)

## What happened 👀

When the guest accesses the application he can do nothing.
He has to sign in to the system first.
 
## Insight 📝

In this PR is the first PR managing the multiple layout.
So we will have 2 layouts for now.
1. Authentication layout
2. Default layout

For the implementation will follow with this link https://nextjs.org/docs/basic-features/layouts
 
## Proof Of Work 📹

Go to `/user/login` 🌈

| Login landing page |
| ------------------- |
| ![Screen Shot 2565-06-02 at 19 38 47](https://user-images.githubusercontent.com/749672/171631072-2a5c87bd-bc54-4388-ac6e-6a9ffd43e1d4.png) |